### PR TITLE
Add navigation links to Markdown files

### DIFF
--- a/0. Overview/0. Overview.md
+++ b/0. Overview/0. Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [README.md](../README.md) | Next: [Architecture.md](Architecture.md)
+
 # Overview #
 
 ## The Snowflake Platform ##

--- a/0. Overview/Architecture.md
+++ b/0. Overview/Architecture.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md) | Previous: [Architecture](Architecture.md) | Next: [Object Model](ObjectModel.md)
+[Back to README](../README.md) | Previous: [0. Overview.md](0. Overview.md) | Next: [DataSharing.md](DataSharing.md)
 
 # Architecture #
 

--- a/0. Overview/DataSharing.md
+++ b/0. Overview/DataSharing.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Architecture.md](Architecture.md) | Next: [Editions.md](Editions.md)
+
 # Data Sharing #
 
 > [Introduction to Secure Data Sharing](https://docs.snowflake.com/en/user-guide/data-sharing-intro.html)

--- a/0. Overview/Editions.md
+++ b/0. Overview/Editions.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md) | Previous: [Architecture](Architecture.md) | Next: [Object Model](ObjectModel.md)
+[Back to README](../README.md) | Previous: [DataSharing.md](DataSharing.md) | Next: [ObjectModel.md](ObjectModel.md)
 
 # Snowflake Editions #
 [Feature / Edition Matrix](https://docs.snowflake.com/en/user-guide/intro-editions#feature-edition-matrix)

--- a/0. Overview/ObjectModel.md
+++ b/0. Overview/ObjectModel.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md) | Previous: [Snowflake Editions](Editions.md) | Next: [Organizations, Accounts, Databases And Schemas](OrganizationsAccountsDatabasesAndSchemas.md)
+[Back to README](../README.md) | Previous: [Editions.md](Editions.md) | Next: [OrganizationsAccountsDatabasesAndSchemas.md](OrganizationsAccountsDatabasesAndSchemas.md)
 
 # Objects #
 * All objects in Snowflake are securable - privileges on objects can be granted to Roles and Roles are granted to Users.
@@ -171,14 +171,14 @@ See [Resource Monitors](../VirtualWarehouses/ResourceMonitors.md)
 Sequences are schema-level objects used to generate unique numbers across sessions and statements, including concurrent statements. They can generate values for a primary key or any column that requires a unique value. They have an initial value and an interval.
 
 You can access sequences in queries as expressions. The function `nextval`, will generate the next unique sequential value.
-```postgres-psql
+\`\`\`postgres-psql
 CREATE OR REPLACE SEQUENCE seq START = 1 INCREMENT = 5;
 CREATE OR REPLACE TABLE PEOPLE 
 (
   ID NUMBER DEFAULT seq.nextval, 
   NAME VARCHAR(50)
 );
-```
+\`\`\`
 
 ## Pipe ##
 A special type of object which enables the automatic loading of data from Stage files as soon as they are available.
@@ -200,9 +200,9 @@ Extend the system to perform operations.
 * Stored Procedures can run multiple SQL statements
 * Stored Procedures are allowed, but not required, to explicitly return a value (such as an error indicator)
 * Stored Procedures are called as independent statements
-  ```postgres-psql
+  \`\`\`postgres-psql
   CALL MyStoredProcedure_1(argument_1);
-  ```
+  \`\`\`
 * The returned values CANNOT be used directly in a SQL statement
 * Every `CREATE PROCEDURE` statement must include a `RETURNS` clause that defines a return type, even if the procedure does not explicitly return anything
 * Store Procedures CANNOT return a set of rows
@@ -234,9 +234,9 @@ UDFs extend Snowflake to perform operations that are not available through built
 * The returned value(s) CAN be used directly in statement SQL
 * While system functions can be listed with `SHOW FUNCTIONS;`, to list UDFs, use `SHOW USER FUNCTIONS;`
 * When calling a UDF which returns a table, you must wrap it in the `TABLE()` function
-  ```postgres-psql
+  \`\`\`postgres-psql
   SELECT * FROM TABLE(MY_UDTF_FUNCTION(param1, param2));
-  ```
+  \`\`\`
 
 ## Data Shares ##
 See [Data Sharing](DataSharing.md)

--- a/0. Overview/OrganizationsAccountsDatabasesAndSchemas.md
+++ b/0. Overview/OrganizationsAccountsDatabasesAndSchemas.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md) | Previous: [Object Model](ObjectModel.md) | Next: [Data Sharing](DataSharing.md)
+[Back to README](../README.md) | Previous: [ObjectModel.md](ObjectModel.md) | Next: [Pricing.md](Pricing.md)
 
 # Organizations, Accounts, Databases And Schemas #
 
@@ -22,4 +22,3 @@
 * A container for database objects such as tables, views, stages, etc.
 * Belongs to a database.
 * Provides a logical grouping for objects.
-

--- a/0. Overview/Pricing.md
+++ b/0. Overview/Pricing.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [OrganizationsAccountsDatabasesAndSchemas.md](OrganizationsAccountsDatabasesAndSchemas.md) | Next: [ResourceMonitors.md](../1. VirtualWarehouses/ResourceMonitors.md)
+
 # Pricing #
 
 Snowflake pricing and cost are based on the actual usage. You pay for what you use and scale storage and compute independently.

--- a/0. Overview/test_file.md
+++ b/0. Overview/test_file.md
@@ -1,0 +1,1 @@
+This is a test file.

--- a/1. VirtualWarehouses/ResourceMonitors.md
+++ b/1. VirtualWarehouses/ResourceMonitors.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Pricing.md](../0. Overview/Pricing.md) | Next: [VirtualWarehouses.md](VirtualWarehouses.md)
+
 # Resource Monitor #
 > [Resource Monitor](https://docs.snowflake.com/en/user-guide/resource-monitors.html)
 

--- a/1. VirtualWarehouses/VirtualWarehouses.md
+++ b/1. VirtualWarehouses/VirtualWarehouses.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ResourceMonitors.md](ResourceMonitors.md) | Next: [DataStorageLayer.md](../2. Storage/DataStorageLayer.md)
+
 # Virtual Warehouses #
 
 Virtual Warehouses (VWs) are the compute layer in Snowflake's architecture. It is a logical wrapper around a cluster of servers with CPU, memory and disk. Data Warehouses are used to perform queries and DML operations (like loading data into tables).

--- a/10. MonitoringAndUsage/BillingAndCost.md
+++ b/10. MonitoringAndUsage/BillingAndCost.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [UDFs_UDTFs.md](../9. SnowparkAndExtensibility/UDFs_UDTFs.md) | Next: [Overview.md](Overview.md)
+
 # Billing and Cost
 
 *Notes related to Monitoring and Usage: Understanding Snowflake billing and managing costs.*

--- a/10. MonitoringAndUsage/Overview.md
+++ b/10. MonitoringAndUsage/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [BillingAndCost.md](BillingAndCost.md) | Next: [QueryHistory.md](QueryHistory.md)
+
 # Overview of Monitoring and Usage
 
 *Notes related to Monitoring and Usage: General overview of monitoring tools and usage information in Snowflake.*

--- a/10. MonitoringAndUsage/QueryHistory.md
+++ b/10. MonitoringAndUsage/QueryHistory.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [UsageMonitoring.md](UsageMonitoring.md)
+
 # Query History
 
 *Notes related to Monitoring and Usage: Understanding and using Query History.*

--- a/10. MonitoringAndUsage/UsageMonitoring.md
+++ b/10. MonitoringAndUsage/UsageMonitoring.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [QueryHistory.md](QueryHistory.md) | Next: [ConnectorsAndDrivers.md](../11. ClientToolsAndConnectivity/ConnectorsAndDrivers.md)
+
 # Usage Monitoring
 
 *Notes related to Monitoring and Usage: Monitoring resource and credit usage.*

--- a/11. ClientToolsAndConnectivity/ConnectorsAndDrivers.md
+++ b/11. ClientToolsAndConnectivity/ConnectorsAndDrivers.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [UsageMonitoring.md](../10. MonitoringAndUsage/UsageMonitoring.md) | Next: [Integrations.md](Integrations.md)
+
 # Connectors and Drivers
 
 *Notes related to Client Tools and Connectivity: Overview of various Snowflake connectors and drivers.*

--- a/11. ClientToolsAndConnectivity/Integrations.md
+++ b/11. ClientToolsAndConnectivity/Integrations.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ConnectorsAndDrivers.md](ConnectorsAndDrivers.md) | Next: [ODBC_JDBC.md](ODBC_JDBC.md)
+
 # Integrations
 
 *Notes related to Client Tools and Connectivity: Snowflake integrations with other tools and services.*

--- a/11. ClientToolsAndConnectivity/ODBC_JDBC.md
+++ b/11. ClientToolsAndConnectivity/ODBC_JDBC.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Integrations.md](Integrations.md) | Next: [Overview.md](Overview.md)
+
 # ODBC and JDBC
 
 *Notes related to Client Tools and Connectivity: Connecting via ODBC and JDBC drivers.*

--- a/11. ClientToolsAndConnectivity/Overview.md
+++ b/11. ClientToolsAndConnectivity/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ODBC_JDBC.md](ODBC_JDBC.md) | Next: [SnowSQL.md](SnowSQL.md)
+
 # Overview of Client Tools and Connectivity
 
 *Notes related to Client Tools and Connectivity: General overview of tools and methods for connecting to Snowflake.*

--- a/11. ClientToolsAndConnectivity/SnowSQL.md
+++ b/11. ClientToolsAndConnectivity/SnowSQL.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [Snowsight.md](Snowsight.md)
+
 # SnowSQL
 
 *Notes related to Client Tools and Connectivity: Using the SnowSQL command-line client.*

--- a/11. ClientToolsAndConnectivity/Snowsight.md
+++ b/11. ClientToolsAndConnectivity/Snowsight.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [SnowSQL.md](SnowSQL.md)
+
 # Snowsight
 
 *Notes related to Client Tools and Connectivity: Using the Snowsight web interface.*

--- a/2. Storage/DataStorageLayer.md
+++ b/2. Storage/DataStorageLayer.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [VirtualWarehouses.md](../1. VirtualWarehouses/VirtualWarehouses.md) | Next: [ZeroCopyCloning.md](ZeroCopyCloning.md)
+
 # Data Storage Layer #
 
 The Data Storage Layer is Snowflake managed cloud-based storage available in the major cloud providers (AWS, Azure and GCP).

--- a/2. Storage/ZeroCopyCloning.md
+++ b/2. Storage/ZeroCopyCloning.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataStorageLayer.md](DataStorageLayer.md) | Next: [BulkLoading.md](../3. DataMovement/BulkLoading.md)
+
 # Zero-Copy Cloning
 
 *Notes related to Storage and Data Protection: Understanding and using Zero-Copy Cloning.*

--- a/3. DataMovement/BulkLoading.md
+++ b/3. DataMovement/BulkLoading.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ZeroCopyCloning.md](../2. Storage/ZeroCopyCloning.md) | Next: [ContinuousDataLoading.md](ContinuousDataLoading.md)
+
 # Bulk Loading #
 
 Bulk load is the process of loading batches of data from files available in a stage into Snowflake tables.

--- a/3. DataMovement/ContinuousDataLoading.md
+++ b/3. DataMovement/ContinuousDataLoading.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md) | Previous: [Bulk Loading](BulkLoading.md) | Next: [Continuous Data Processing](ContinuousDataProcessing.md)
+[Back to README](../README.md) | Previous: [BulkLoading.md](BulkLoading.md) | Next: [ContinuousDataProcessing.md](ContinuousDataProcessing.md)
 
 # Continuous Loading #
 

--- a/3. DataMovement/ContinuousDataProcessing.md
+++ b/3. DataMovement/ContinuousDataProcessing.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ContinuousDataLoading.md](ContinuousDataLoading.md) | Next: [DataUnloading.md](DataUnloading.md)
+
 # Continuous Processing #
 
 ## Tasks ##

--- a/3. DataMovement/DataUnloading.md
+++ b/3. DataMovement/DataUnloading.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ContinuousDataProcessing.md](ContinuousDataProcessing.md) | Next: [Overview.md](Overview.md)
+
 # Data Unloading #
 
 Similar to [Bulk Loading](BulkLoading.md), unloading uses the `COPY INTO` command to unload data to an internal or external stage. The difference is that, when unloading, we would

--- a/3. DataMovement/Overview.md
+++ b/3. DataMovement/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataUnloading.md](DataUnloading.md) | Next: [AccessControl.md](../4. AccountAndSecurity/AccessControl.md)
+
 # Data Movement #
 
 Loading and unloading data into Snowflake can be:

--- a/4. AccountAndSecurity/AccessControl.md
+++ b/4. AccountAndSecurity/AccessControl.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](../3. DataMovement/Overview.md) | Next: [Authentication.md](Authentication.md)
+
 # Access Control #
 
 > [Overview of Access Control](https://docs.snowflake.com/en/user-guide/security-access-control-overview.html)

--- a/4. AccountAndSecurity/Authentication.md
+++ b/4. AccountAndSecurity/Authentication.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [AccessControl.md](AccessControl.md) | Next: [Authorization.md](Authorization.md)
+
 # Authentication #
 
 Identifies the user and confirms whether they are allowed to login.

--- a/4. AccountAndSecurity/Authorization.md
+++ b/4. AccountAndSecurity/Authorization.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Authentication.md](Authentication.md) | Next: [DataProtection.md](DataProtection.md)
+
 # Authorization #
 
 Snowflake's authorization model is a combination of:
@@ -86,4 +88,3 @@ SHOW GRANTS OF ROLE <ROLE>;
     AND auth_table.role = CURRENT_ROLE()
   ;
   ```
-

--- a/4. AccountAndSecurity/DataProtection.md
+++ b/4. AccountAndSecurity/DataProtection.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Authorization.md](Authorization.md) | Next: [Overview.md](Overview.md)
+
 # Data Protection #
 
 > [Continuous Data Protection](https://docs.snowflake.com/en/user-guide/data-cdp.html)

--- a/4. AccountAndSecurity/Overview.md
+++ b/4. AccountAndSecurity/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataProtection.md](DataProtection.md) | Next: [Caching.md](../5. PerformanceAndTuning/Caching.md)
+
 # Account and Security Overview #
 
 ## Security Aspects ##

--- a/5. PerformanceAndTuning/Caching.md
+++ b/5. PerformanceAndTuning/Caching.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](../4. AccountAndSecurity/Overview.md) | Next: [DataClustering.md](DataClustering.md)
+
 # Caching #
 
 One of the most important ways to improve the speed of queries in Snowflake and optimize costs is the cache. There are several different caches in Snowflake: Metadata, Query Result, and Warehouse cache.

--- a/5. PerformanceAndTuning/DataClustering.md
+++ b/5. PerformanceAndTuning/DataClustering.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Caching.md](Caching.md) | Next: [MaterializedViews.md](MaterializedViews.md)
+
 # Data Clustering #
 
 ## Clustering ##

--- a/5. PerformanceAndTuning/MaterializedViews.md
+++ b/5. PerformanceAndTuning/MaterializedViews.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataClustering.md](DataClustering.md) | Next: [Overview.md](Overview.md)
+
 # Materialized Views
 
 *Notes related to Performance and Tuning: Understanding and using Materialized Views.*

--- a/5. PerformanceAndTuning/Overview.md
+++ b/5. PerformanceAndTuning/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [MaterializedViews.md](MaterializedViews.md) | Next: [VirtualWarehouseScaling.md](VirtualWarehouseScaling.md)
+
 # Performance and Tuning Overview #
 
 ## Query Optimizer Workflow ##

--- a/5. PerformanceAndTuning/VirtualWarehouseScaling.md
+++ b/5. PerformanceAndTuning/VirtualWarehouseScaling.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [LoadAndUnloadSemiStructuredData.md](../6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md)
+
 # Virtual Warehouse Scaling #
 
 * As queries are submitted, resources are calculated and reserved prior to the query execution

--- a/6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md
+++ b/6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [VirtualWarehouseScaling.md](../5. PerformanceAndTuning/VirtualWarehouseScaling.md) | Next: [Overview.md](Overview.md)
+
 # Load and Unload Semi-Structured Data #
 
 ## Create File Format ##

--- a/6. SemiStructuredData/Overview.md
+++ b/6. SemiStructuredData/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [LoadAndUnloadSemiStructuredData.md](LoadAndUnloadSemiStructuredData.md) | Next: [QuerySemiStructuredData.md](QuerySemiStructuredData.md)
+
 # Semi-Structured Data Overview #
 
 Snowflake supports the following semi-structured data file formats:

--- a/6. SemiStructuredData/QuerySemiStructuredData.md
+++ b/6. SemiStructuredData/QuerySemiStructuredData.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [DDL_DML.md](../7. SQLAndQuerying/DDL_DML.md)
+
 # Query Semi-Structured Data #
 
 ```

--- a/7. SQLAndQuerying/DDL_DML.md
+++ b/7. SQLAndQuerying/DDL_DML.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [QuerySemiStructuredData.md](../6. SemiStructuredData/QuerySemiStructuredData.md) | Next: [Functions.md](Functions.md)
+
 # DDL and DML
 
 *Notes related to SQL and Querying: Data Definition Language (DDL) and Data Manipulation Language (DML) commands.*

--- a/7. SQLAndQuerying/Functions.md
+++ b/7. SQLAndQuerying/Functions.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DDL_DML.md](DDL_DML.md) | Next: [Overview.md](Overview.md)
+
 # Functions
 
 *Notes related to SQL and Querying: Built-in and user-defined functions.*

--- a/7. SQLAndQuerying/Overview.md
+++ b/7. SQLAndQuerying/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Functions.md](Functions.md) | Next: [QueryBestPractices.md](QueryBestPractices.md)
+
 # Overview of SQL and Querying
 
 *Notes related to SQL and Querying: General overview of SQL capabilities in Snowflake.*

--- a/7. SQLAndQuerying/QueryBestPractices.md
+++ b/7. SQLAndQuerying/QueryBestPractices.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [DataExchange.md](../8. MarketplaceAndDataExchange/DataExchange.md)
+
 # Query Best Practices
 
 *Notes related to SQL and Querying: Best practices for writing efficient queries in Snowflake.*

--- a/8. MarketplaceAndDataExchange/DataExchange.md
+++ b/8. MarketplaceAndDataExchange/DataExchange.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [QueryBestPractices.md](../7. SQLAndQuerying/QueryBestPractices.md) | Next: [DataMarketplace.md](DataMarketplace.md)
+
 # Data Exchange
 
 *Notes related to Marketplace and Data Exchange: Snowflake Data Exchange.*

--- a/8. MarketplaceAndDataExchange/DataMarketplace.md
+++ b/8. MarketplaceAndDataExchange/DataMarketplace.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataExchange.md](DataExchange.md) | Next: [Overview.md](Overview.md)
+
 # Data Marketplace
 
 *Notes related to Marketplace and Data Exchange: Snowflake Data Marketplace.*

--- a/8. MarketplaceAndDataExchange/Overview.md
+++ b/8. MarketplaceAndDataExchange/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [DataMarketplace.md](DataMarketplace.md) | Next: [ExternalFunctions.md](../9. SnowparkAndExtensibility/ExternalFunctions.md)
+
 # Overview of Marketplace and Data Exchange
 
 *Notes related to Marketplace and Data Exchange: General overview of Snowflake Data Marketplace and Data Exchange.*

--- a/9. SnowparkAndExtensibility/ExternalFunctions.md
+++ b/9. SnowparkAndExtensibility/ExternalFunctions.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](../8. MarketplaceAndDataExchange/Overview.md) | Next: [Overview.md](Overview.md)
+
 # External Functions
 
 *Notes related to Snowpark and Extensibility: Using External Functions.*

--- a/9. SnowparkAndExtensibility/Overview.md
+++ b/9. SnowparkAndExtensibility/Overview.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [ExternalFunctions.md](ExternalFunctions.md) | Next: [Snowpark.md](Snowpark.md)
+
 # Overview of Snowpark and Extensibility
 
 *Notes related to Snowpark and Extensibility: General overview of extending Snowflake's capabilities.*

--- a/9. SnowparkAndExtensibility/Snowpark.md
+++ b/9. SnowparkAndExtensibility/Snowpark.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [StoredProcedures.md](StoredProcedures.md)
+
 # Snowpark
 
 *Notes related to Snowpark and Extensibility: Using Snowpark for data engineering and data science.*

--- a/9. SnowparkAndExtensibility/StoredProcedures.md
+++ b/9. SnowparkAndExtensibility/StoredProcedures.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [Snowpark.md](Snowpark.md) | Next: [UDFs_UDTFs.md](UDFs_UDTFs.md)
+
 # Stored Procedures
 
 *Notes related to Snowpark and Extensibility: Creating and using Stored Procedures.*

--- a/9. SnowparkAndExtensibility/UDFs_UDTFs.md
+++ b/9. SnowparkAndExtensibility/UDFs_UDTFs.md
@@ -1,3 +1,5 @@
+[Back to README](../README.md) | Previous: [StoredProcedures.md](StoredProcedures.md) | Next: [BillingAndCost.md](../10. MonitoringAndUsage/BillingAndCost.md)
+
 # UDFs and UDTFs
 
 *Notes related to Snowpark and Extensibility: User-Defined Functions (UDFs) and User-Defined Table Functions (UDTFs).*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Next: [0. Overview.md](0. Overview/0. Overview.md)
+
 # Snowflake Snow Pro Core Exam Preparation Course Notes #
 
 > * [SnowPro Certifications](https://www.snowflake.com/certifications/)
@@ -85,8 +87,8 @@ Read every single “Reading Assets” article from the [[COF-C02] SnowPro Core 
 
 ### Topics Quizzed on Exams ###
 * [Working with Secure Views](https://docs.snowflake.com/en/user-guide/views-secure.html)
-* [Working with Resource Monitors](https://docs.snowflake.com/en/user-guide/resource-monitors.html)
-* [Directory Tables](https://docs.snowflake.com/en/user-guide/data-load-dirtables.html)
+* [Working with Resource Monitors](https://docs.snowflake.com/en-user-guide/resource-monitors.html)
+* [Directory Tables](https://docs.snowflake.com/en-user-guide/data-load-dirtables.html)
 
 ### Sample Exams ###
 


### PR DESCRIPTION
This change adds a navigation header to the top of each Markdown file. The header includes links to:
- Return to the main README.md
- Go to the previous Markdown file in the sequence
- Go to the next Markdown file in the sequence

This improves the browsability of the documentation. The file order for previous/next links was determined by first the main README, then by numerical order of parent directories, and finally by alphabetical order of filenames within each directory.