### PR TITLE
Adds footer navigation

### DIFF
--- a/0. Overview/0. Overview.md
+++ b/0. Overview/0. Overview.md
@@ -92,3 +92,6 @@
 
 ## Free Trial ##
 You can apply for a 30-day free trial at the following link https://signup.snowflake.com/. Trying out the Enterprise edition is recommended.
+
+
+[Back to README](../README.md) | Previous: [README.md](../README.md) | Next: [Architecture.md](Architecture.md)

--- a/0. Overview/Architecture.md
+++ b/0. Overview/Architecture.md
@@ -70,3 +70,6 @@ Snowflake's unique architecture consists of three layers, all of them with High 
 * Availability
 * Transparent online updates and patches
 * Runs on Snowflake-managed compute
+
+
+[Back to README](../README.md) | Previous: [0. Overview.md](0. Overview.md) | Next: [DataSharing.md](DataSharing.md)

--- a/0. Overview/DataSharing.md
+++ b/0. Overview/DataSharing.md
@@ -86,3 +86,6 @@ The preferred way to share data is by using Secure Views:
 ## Types ##
 * Public Data Marketplace
 * Private Data Exchange
+
+
+[Back to README](../README.md) | Previous: [Architecture.md](Architecture.md) | Next: [Editions.md](Editions.md)

--- a/0. Overview/Editions.md
+++ b/0. Overview/Editions.md
@@ -87,3 +87,6 @@ Business Critical Edition but in a completely separate Snowflake environment, is
 
 ## Government Regions ##
 For government agencies that require compliance with US federal privacy and security standards, such as FIPS 140–2 and FedRAMP, Snowflake provides support for those only on Amazon Web Services and Azure. These government regions are only supported on Business-Critical Edition or higher.
+
+
+[Back to README](../README.md) | Previous: [DataSharing.md](DataSharing.md) | Next: [ObjectModel.md](ObjectModel.md)

--- a/0. Overview/ObjectModel.md
+++ b/0. Overview/ObjectModel.md
@@ -240,3 +240,6 @@ UDFs extend Snowflake to perform operations that are not available through built
 
 ## Data Shares ##
 See [Data Sharing](DataSharing.md)
+
+
+[Back to README](../README.md) | Previous: [Editions.md](Editions.md) | Next: [OrganizationsAccountsDatabasesAndSchemas.md](OrganizationsAccountsDatabasesAndSchemas.md)

--- a/0. Overview/OrganizationsAccountsDatabasesAndSchemas.md
+++ b/0. Overview/OrganizationsAccountsDatabasesAndSchemas.md
@@ -22,3 +22,6 @@
 * A container for database objects such as tables, views, stages, etc.
 * Belongs to a database.
 * Provides a logical grouping for objects.
+
+
+[Back to README](../README.md) | Previous: [ObjectModel.md](ObjectModel.md) | Next: [Pricing.md](Pricing.md)

--- a/0. Overview/Pricing.md
+++ b/0. Overview/Pricing.md
@@ -39,3 +39,6 @@ Customers who wish to move or copy their data between regions or cloud providers
 * Pre-paid: Pre-purchase Capacity, which involves a commitment to Snowflake. The Capacity purchased is then consumed monthly, providing lower prices and a long-term price guarantee, among other advantages.
 
 ![](../images/OnDemandVsPrePurchaseCapacityForStorage.webp)
+
+
+[Back to README](../README.md) | Previous: [OrganizationsAccountsDatabasesAndSchemas.md](OrganizationsAccountsDatabasesAndSchemas.md) | Next: [ResourceMonitors.md](../1. VirtualWarehouses/ResourceMonitors.md)

--- a/1. VirtualWarehouses/ResourceMonitors.md
+++ b/1. VirtualWarehouses/ResourceMonitors.md
@@ -62,3 +62,6 @@ If a Resource Monitor suspends a Warehouse, it cannot be restarted unless one of
 * The credit threshold for the suspend action is increased. 
 * The warehouses are no longer assigned to the monitor. 
 * The monitor is dropped.
+
+
+[Back to README](../README.md) | Previous: [Pricing.md](../0. Overview/Pricing.md) | Next: [VirtualWarehouses.md](VirtualWarehouses.md)

--- a/1. VirtualWarehouses/VirtualWarehouses.md
+++ b/1. VirtualWarehouses/VirtualWarehouses.md
@@ -63,3 +63,6 @@ A transaction is a sequence of SQL statements that are committed or rolled back 
 * You can abort a running transaction with the system function `SYSTEM$ABORT_TRANSACTION `
 * Each transaction has independent scope
 * Snowflake does not support nested Transactions, although it supports nested Stored Procedure calls
+
+
+[Back to README](../README.md) | Previous: [ResourceMonitors.md](ResourceMonitors.md) | Next: [DataStorageLayer.md](../2. Storage/DataStorageLayer.md)

--- a/10. MonitoringAndUsage/Overview.md
+++ b/10. MonitoringAndUsage/Overview.md
@@ -13,3 +13,6 @@
     *   **Snowsight:** Web UI providing dashboards and detailed views for query history, warehouse usage, storage, tasks, etc.
     *   **SQL:** Querying `ACCOUNT_USAGE` schema views and `INFORMATION_SCHEMA` table functions.
 *   **Key Areas to Monitor:** Query performance, warehouse utilization, storage consumption, credit usage, data loading processes, task execution, security events.
+
+
+[Back to README](../README.md) | Previous: [BillingAndCost.md](BillingAndCost.md) | Next: [QueryHistory.md](QueryHistory.md)

--- a/11. ClientToolsAndConnectivity/Integrations.md
+++ b/11. ClientToolsAndConnectivity/Integrations.md
@@ -17,3 +17,6 @@
 *   **SQL IDEs & Development Tools:**
     *   DBeaver, DataGrip, VS Code with SQL extensions.
 *   **Partner Connect:** Simplified trial and connection setup for select partners directly from Snowsight.
+
+
+[Back to README](../README.md) | Previous: [ConnectorsAndDrivers.md](ConnectorsAndDrivers.md) | Next: [ODBC_JDBC.md](ODBC_JDBC.md)

--- a/11. ClientToolsAndConnectivity/ODBC_JDBC.md
+++ b/11. ClientToolsAndConnectivity/ODBC_JDBC.md
@@ -16,3 +16,6 @@
     *   Connection URL format and parameters.
     *   Use cases: Java applications, ETL tools, SQL IDEs (e.g., DBeaver, DataGrip).
 *   **Authentication Methods:** Supported authenticators with drivers (e.g., password, OAuth, key pair, external browser).
+
+
+[Back to README](../README.md) | Previous: [Integrations.md](Integrations.md) | Next: [Overview.md](Overview.md)

--- a/11. ClientToolsAndConnectivity/Overview.md
+++ b/11. ClientToolsAndConnectivity/Overview.md
@@ -11,3 +11,6 @@
     *   SnowSQL (Command-Line Client).
 *   **Drivers:** ODBC, JDBC, Python Connector, Go Driver, .NET Driver, Node.js Driver.
 *   **Third-Party Ecosystem:** BI tools, ETL/ELT tools, Data Science platforms, SQL IDEs.
+
+
+[Back to README](../README.md) | Previous: [ODBC_JDBC.md](ODBC_JDBC.md) | Next: [SnowSQL.md](SnowSQL.md)

--- a/11. ClientToolsAndConnectivity/Snowsight.md
+++ b/11. ClientToolsAndConnectivity/Snowsight.md
@@ -19,3 +19,6 @@
         *   Account: General account settings, billing, security.
     *   **Marketplace:** Accessing third-party data.
 *   **Context Switching:** Changing role, warehouse, database, schema.
+
+
+[Back to README](../README.md) | Previous: [SnowSQL.md](SnowSQL.md)

--- a/2. Storage/DataStorageLayer.md
+++ b/2. Storage/DataStorageLayer.md
@@ -46,3 +46,6 @@ The Cloud Services Layer metadata also allows the processing of certain queries 
     * Billed upfront for committed storage capacity
     * Price varies depending on cloud platform
     * Customer is notified when they have consumed 70% of pre-purchased capacity
+
+
+[Back to README](../README.md) | Previous: [VirtualWarehouses.md](../1. VirtualWarehouses/VirtualWarehouses.md) | Next: [ZeroCopyCloning.md](ZeroCopyCloning.md)

--- a/2. Storage/ZeroCopyCloning.md
+++ b/2. Storage/ZeroCopyCloning.md
@@ -14,3 +14,6 @@
     *   Creating sandboxes for data analysis or experimentation.
 *   **Syntax:** `CREATE <object_type> <clone_name> CLONE <source_object_name> [AT | BEFORE (TIMESTAMP | OFFSET | STATEMENT => '<statement_id>')]`
 *   **Impact on Time Travel:** Clones inherit the Time Travel history of the source object up to the point of cloning.
+
+
+[Back to README](../README.md) | Previous: [DataStorageLayer.md](DataStorageLayer.md) | Next: [BulkLoading.md](../3. DataMovement/BulkLoading.md)

--- a/3. DataMovement/BulkLoading.md
+++ b/3. DataMovement/BulkLoading.md
@@ -71,3 +71,6 @@ VALIDATE([namespace.]<table_name>,
   JOB_ID => { '<query_id>' | _last }
 );
 ```
+
+
+[Back to README](../README.md) | Previous: [ZeroCopyCloning.md](../2. Storage/ZeroCopyCloning.md) | Next: [ContinuousDataLoading.md](ContinuousDataLoading.md)

--- a/3. DataMovement/ContinuousDataLoading.md
+++ b/3. DataMovement/ContinuousDataLoading.md
@@ -39,3 +39,6 @@ Once Snowpipe receives a trigger for the ingestion, whether via the REST API or 
 Customers are billed for the cloud compute used by Snowpipe per-second, per-core on actual compute usage.
 
 In addition to the cloud compute costs, there is an utilization cost charge of 0.06 credits per 1000 files notified by using the REST API or `AUTO_INGEST`
+
+
+[Back to README](../README.md) | Previous: [BulkLoading.md](BulkLoading.md) | Next: [ContinuousDataProcessing.md](ContinuousDataProcessing.md)

--- a/3. DataMovement/ContinuousDataProcessing.md
+++ b/3. DataMovement/ContinuousDataProcessing.md
@@ -82,3 +82,6 @@ When created, a table stream logically takes an initial snapshot of every row in
   * if the row has not been modified, there will be no Stream record at all
   * if the row was modified but then it was reverted to its original state when the stream was first created, the Stream record for that row will be removed
 * Multiple streams can be created for the same table and consumed by different tasks
+
+
+[Back to README](../README.md) | Previous: [ContinuousDataLoading.md](ContinuousDataLoading.md) | Next: [DataUnloading.md](DataUnloading.md)

--- a/3. DataMovement/DataUnloading.md
+++ b/3. DataMovement/DataUnloading.md
@@ -37,3 +37,6 @@ GET @my_int_stage file:///tmp/data/;
 * `FIELD_OPTIONALLY_ENCLOSED_BY` - specify the character to use to enclose your fields
 * `EMPTY_FIELD_AS_NULL` - convert empty fields into `NULL`, the default is `FALSE`
 * `NULL_IF` - convert `NULL` values to something else
+
+
+[Back to README](../README.md) | Previous: [ContinuousDataProcessing.md](ContinuousDataProcessing.md) | Next: [Overview.md](Overview.md)

--- a/3. DataMovement/Overview.md
+++ b/3. DataMovement/Overview.md
@@ -39,3 +39,6 @@ A schema-level named object which defines the format information required for Sn
   * A File Format can be attached to a stage - automatically associates the File Format for all files stored in the stage
   * A File Format can be attached to a table - automatically associates the File Format for all `COPY INTO` commands targeting the table
   * A File Format can be specified for each `COPY INTO` command which will override the stage or table ones, if specified
+
+
+[Back to README](../README.md) | Previous: [DataUnloading.md](DataUnloading.md) | Next: [AccessControl.md](../4. AccountAndSecurity/AccessControl.md)

--- a/4. AccountAndSecurity/AccessControl.md
+++ b/4. AccountAndSecurity/AccessControl.md
@@ -47,3 +47,6 @@ ALTER USER <username> SET NETW0RK_POLICY = <policy_name>;
 * Allow hostnames:
   * all Snowflake clients require temporary access to the provider cloud storage
   * `SYSTEM$ALLOW_LIST()` lists the required hostnames for your Snowflake account
+
+
+[Back to README](../README.md) | Previous: [Overview.md](../3. DataMovement/Overview.md) | Next: [Authentication.md](Authentication.md)

--- a/4. AccountAndSecurity/Authentication.md
+++ b/4. AccountAndSecurity/Authentication.md
@@ -16,3 +16,6 @@ Identifies the user and confirms whether they are allowed to login.
   * Oauth: authentication from a 3rd party service or application
   * Key Pair: JSON Web Token (JWT) signed with a private/public RSA key pair
   * SCIM (System Cross-domain Identity Management): often used in Azure or Okta
+
+
+[Back to README](../README.md) | Previous: [AccessControl.md](AccessControl.md) | Next: [Authorization.md](Authorization.md)

--- a/4. AccountAndSecurity/DataProtection.md
+++ b/4. AccountAndSecurity/DataProtection.md
@@ -107,3 +107,6 @@ Non-configurable, 7-day retention for historical data after the Time Travel expi
 
 ### Snowflake replication features ###
 Snowflake provides customers with additional replication features, over and above the cloud providers' replication across availability zones.
+
+
+[Back to README](../README.md) | Previous: [Authorization.md](Authorization.md) | Next: [Overview.md](Overview.md)

--- a/4. AccountAndSecurity/Overview.md
+++ b/4. AccountAndSecurity/Overview.md
@@ -18,3 +18,6 @@
 * HIPAA (Snowflake Business Critical Edition)
 * PCI (Snowflake Business Critical Edition)
 * FedRAMP (Snowflake Business Critical Edition)
+
+
+[Back to README](../README.md) | Previous: [DataProtection.md](DataProtection.md) | Next: [Caching.md](../5. PerformanceAndTuning/Caching.md)

--- a/5. PerformanceAndTuning/Caching.md
+++ b/5. PerformanceAndTuning/Caching.md
@@ -32,3 +32,6 @@ The actual SQL is executed across the nodes of a Virtual Data Warehouse. This la
 * You can get information on how much data is read from Local (Warehouse) storage vs. Remote (Storage layer) by inspecting the query profile's "Scanned Bytes" metric.
 * It is recommended to use dedicated Virtual Warehouses for similar workloads. For example, a Virtual Warehouse for BI tasks, another for Data Science, etc. There is a chance that data cached by the warehouse for similar queries can can be re-used
 * The larger a warehouse is, the larger the warehouse cache size is
+
+
+[Back to README](../README.md) | Previous: [Overview.md](../4. AccountAndSecurity/Overview.md) | Next: [DataClustering.md](DataClustering.md)

--- a/5. PerformanceAndTuning/DataClustering.md
+++ b/5. PerformanceAndTuning/DataClustering.md
@@ -65,3 +65,6 @@ CLUSTER BY (<column_or_expression>, ...)
   * `partition_depth_histogram` with a high number of low value depths
 * You can cluster materialized views, as well as tables
 * Snowflake recommends a maximum of 3 or 4 columns (or expressions) per key.
+
+
+[Back to README](../README.md) | Previous: [Caching.md](Caching.md) | Next: [MaterializedViews.md](MaterializedViews.md)

--- a/5. PerformanceAndTuning/MaterializedViews.md
+++ b/5. PerformanceAndTuning/MaterializedViews.md
@@ -13,3 +13,6 @@
 *   **Use Cases:** Accelerating dashboards, BI reports, and common analytical queries.
 *   **Limitations and Considerations:** Restrictions on query definitions (e.g., no non-deterministic functions, no UDFs, specific join types), impact of base table changes on refresh costs.
 *   **Monitoring:** `MATERIALIZED_VIEW_REFRESH_HISTORY` in `ACCOUNT_USAGE`.
+
+
+[Back to README](../README.md) | Previous: [DataClustering.md](DataClustering.md) | Next: [Overview.md](Overview.md)

--- a/5. PerformanceAndTuning/Overview.md
+++ b/5. PerformanceAndTuning/Overview.md
@@ -33,3 +33,6 @@ Typical workflow of the Snowflake query optimizer:
 These can be set for at the Account/Session/Role or Virtual Warehouse level:
 * `STATEMENT_TIMEOUT_IN_SECONDS`: How long can a query run before being cancelled by the system, Default: 2 days
 * `STATEMENT_QUEUED_TIMEOUT_IN_SECONDS`:  How long can a queued query wait before being cancelled by the system, Default: 0 (forever)
+
+
+[Back to README](../README.md) | Previous: [MaterializedViews.md](MaterializedViews.md) | Next: [VirtualWarehouseScaling.md](VirtualWarehouseScaling.md)

--- a/5. PerformanceAndTuning/VirtualWarehouseScaling.md
+++ b/5. PerformanceAndTuning/VirtualWarehouseScaling.md
@@ -58,3 +58,6 @@ Multi-cluster warehouses can work in
 
 ## Scaling Considerations ##
 * Query processing cannot cross clusters, so, even though the number or clusters is the same, a complex query will perform differently on a 4-cluster multi-cluster warehouse made of `X-Small` clusters compared to a single-cluster `Medium` warehouse.
+
+
+[Back to README](../README.md) | Previous: [Overview.md](Overview.md) | Next: [LoadAndUnloadSemiStructuredData.md](../6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md)

--- a/6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md
+++ b/6. SemiStructuredData/LoadAndUnloadSemiStructuredData.md
@@ -109,3 +109,6 @@ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
 * Supported formats
   * JSON: Unload from a `VARIANT` column or reconstruct a JSON format
   * Parquet: Use a `SELECT` to unload the table columns into a Parquet file
+
+
+[Back to README](../README.md) | Previous: [VirtualWarehouseScaling.md](../5. PerformanceAndTuning/VirtualWarehouseScaling.md) | Next: [Overview.md](Overview.md)

--- a/6. SemiStructuredData/Overview.md
+++ b/6. SemiStructuredData/Overview.md
@@ -19,3 +19,6 @@ Semi-structured data is supported using the `VARIANT` data type:
 * Arrays - collection of values where each value is a `VARIANT`
 * non-native values (e.g. dates, timestamps) are stored as strings in `VARIANT` columns
 * operations can be slower than when stored as the corresponding data type
+
+
+[Back to README](../README.md) | Previous: [LoadAndUnloadSemiStructuredData.md](LoadAndUnloadSemiStructuredData.md) | Next: [QuerySemiStructuredData.md](QuerySemiStructuredData.md)

--- a/7. SQLAndQuerying/Functions.md
+++ b/7. SQLAndQuerying/Functions.md
@@ -17,3 +17,6 @@
     *   **Java UDFs (via Snowpark):** Scalar or tabular, leverage Java ecosystem.
     *   **Python UDFs (via Snowpark):** Scalar or tabular, leverage Python ecosystem.
 *   **User-Defined Table Functions (UDTFs):** Functions that return a set of rows, often used with JavaScript, Java, or Python.
+
+
+[Back to README](../README.md) | Previous: [DDL_DML.md](DDL_DML.md) | Next: [Overview.md](Overview.md)

--- a/7. SQLAndQuerying/Overview.md
+++ b/7. SQLAndQuerying/Overview.md
@@ -12,3 +12,6 @@
     *   Functions and operators specific to Snowflake for handling semi-structured data, date/time manipulations, etc.
     *   Features like `QUALIFY`, `CONNECT BY`, `PIVOT`/`UNPIVOT`.
 *   **Query Processing:** Brief overview of how Snowflake processes SQL queries.
+
+
+[Back to README](../README.md) | Previous: [Functions.md](Functions.md) | Next: [QueryBestPractices.md](QueryBestPractices.md)

--- a/8. MarketplaceAndDataExchange/DataExchange.md
+++ b/8. MarketplaceAndDataExchange/DataExchange.md
@@ -12,3 +12,6 @@
 *   **For Consumers within the Exchange:** Discovering and accessing data shared by other members.
 *   **Use Cases:** Sharing data with business partners, suppliers, customers, or between internal business units.
 *   **Governance and Control:** Maintaining control over who can join and what data is shared.
+
+
+[Back to README](../README.md) | Previous: [QueryBestPractices.md](../7. SQLAndQuerying/QueryBestPractices.md) | Next: [DataMarketplace.md](DataMarketplace.md)

--- a/9. SnowparkAndExtensibility/Overview.md
+++ b/9. SnowparkAndExtensibility/Overview.md
@@ -13,3 +13,6 @@
 *   **Stored Procedures:** Encapsulating complex SQL and procedural logic.
 *   **External Functions:** Integrating with code running outside Snowflake.
 *   **Benefits:** Centralized data governance, reduced data movement, leveraging existing code and skills.
+
+
+[Back to README](../README.md) | Previous: [ExternalFunctions.md](ExternalFunctions.md) | Next: [Snowpark.md](Snowpark.md)

--- a/9. SnowparkAndExtensibility/UDFs_UDTFs.md
+++ b/9. SnowparkAndExtensibility/UDFs_UDTFs.md
@@ -23,3 +23,6 @@
     *   Support procedural logic, SQL execution, variable handling.
     *   Languages: SQL (Scripting), JavaScript, Java (Snowpark), Python (Snowpark), Scala (Snowpark).
 *   **Performance Considerations:** Language choice, complexity of logic.
+
+
+[Back to README](../README.md) | Previous: [StoredProcedures.md](StoredProcedures.md) | Next: [BillingAndCost.md](../10. MonitoringAndUsage/BillingAndCost.md)

--- a/README.md
+++ b/README.md
@@ -106,3 +106,6 @@ Obs: There are quite a lot of ambiguous questions and the showing result might n
 * [Udemy: [COF-C02] Snowflake SnowPro Core Certification Practice Sets](https://www.udemy.com/course/snowflake-snowpro-core-certification-exam-practice-sets/)
 
 * [Snowflake SnowPro Core Practice Exams (2025)] (https://certificationpractice.com/practice-exams/snowflake-snowpro-core/)
+
+
+Next: [0. Overview.md](0. Overview/0. Overview.md)


### PR DESCRIPTION
This change adds a navigation footer to the bottom of each Markdown file, mirroring the navigation header already present. The footer includes links to:
- Return to the main README.md
- Go to the previous Markdown file in the sequence
- Go to the next Markdown file in the sequence

This further improves the browsability of the documentation, allowing you to navigate easily from the bottom of a file as well as the top. The file order for previous/next links is consistent with the headers.